### PR TITLE
Update MailHelper.php

### DIFF
--- a/app/bundles/EmailBundle/Helper/MailHelper.php
+++ b/app/bundles/EmailBundle/Helper/MailHelper.php
@@ -980,7 +980,7 @@ class MailHelper
         $content = strtr($content, $this->embedImagesReplaces);
         if (preg_match_all('/<img.+?src=[\"\'](.+?)[\"\'].*?>/i', $content, $matches)) {
             foreach ($matches[1] as $match) {
-                if (false === strpos($match, 'cid:')) {
+                if (false === strpos($match, 'cid:') and !array_key_exists($match,$this->embedImagesReplaces)) {
                     $this->embedImagesReplaces[$match] = $this->message->embed(\Swift_Image::fromPath($match));
                 }
             }


### PR DESCRIPTION
To avoid that if the same image is referenced multiple times in the message, it gets added multiple times (even when only one reference will be used).

https://github.com/mautic/mautic/issues/8995

| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | NA
| Related developer documentation PR URL | NA
| Issue(s) addressed                     | Fixes #8995

#### Description: To avoid that if the same image is referenced multiple times in the message, it gets embedded multiple times (even when only one reference will be used).
