### PR TITLE
Update AjaxController.php

### DIFF
--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -463,7 +463,7 @@ class AjaxController extends CommonAjaxController
             /** @var \Mautic\LeadBundle\Model\LeadModel $model */
 
             /** @var DoNotContactModel $doNotContact */
-            $doNotContact = $this->getModel('mautic.lead.model.dnc');
+            $doNotContact = $this->getModel('lead.dnc');
 
             /** @var DoNotContactModel $dnc */
             $dnc = $this->getDoctrine()->getManager()->getRepository('MauticLeadBundle:DoNotContact')->findOneBy(

--- a/app/bundles/LeadBundle/Controller/AjaxController.php
+++ b/app/bundles/LeadBundle/Controller/AjaxController.php
@@ -348,7 +348,7 @@ class AjaxController extends CommonAjaxController
         if (!empty($leadId) && !empty($channel) && in_array($action, ['remove', 'add'])) {
             $leadModel = $this->getModel('lead');
             /** @var DoNotContactModel $doNotContact */
-            $doNotContact = $this->getModel('mautic.lead.model.dnc');
+            $doNotContact = $this->getModel('lead.dnc');
 
             $lead = $leadModel->getEntity($leadId);
 


### PR DESCRIPTION
To avoid 500 Internal Server Error while removing the "Do not contact" tag from a contact's preferences, as described in https://github.com/mautic/mautic/issues/9017


| Q                                      | A
| -------------------------------------- | ---
| Branch?                                | 3.0 
| Bug fix?                               | yes
| New feature?                           | no
| Deprecations?                          | no
| BC breaks?                             | no
| Automated tests included?              | no
| Related user documentation PR URL      | 
| Related developer documentation PR URL | 
| Issue(s) addressed                     | Fixes #9017


#### Description:
Change model name (mautic.lead.model.dnc -> lead.dnc) to avoid error.  getModel composes the full name from the short one.